### PR TITLE
Add tests for ChatRoom utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "npx -y vitest run"
   },
   "dependencies": {
     "axios": "^1.6.8",

--- a/src/pages/ChatRoom.jsx
+++ b/src/pages/ChatRoom.jsx
@@ -7,8 +7,13 @@ const COMMON_EMOJI = ["😀","😂","😍","😎","😭","🤔","🙌","🔥","�
 const pad = (n) => (n < 10 ? "0" : "") + n;
 function fmt(ts){ const d=new Date(ts); return pad(d.getHours())+":"+pad(d.getMinutes()); }
 function dayLabel(ts){ const d=new Date(ts); return d.toLocaleDateString(); }
-function autolink(text){ return text.replace(/(https?:\/\/[^\s]+)/g,'<a class="autolink" target="_blank" rel="noreferrer" href="$1">$1</a>'); }
-function highlightMentions(text, you){
+export function autolink(text){
+  return text.replace(
+    /(https?:\/\/[^\s]+)/g,
+    '<a class="autolink" target="_blank" rel="noreferrer" href="$1">$1</a>'
+  );
+}
+export function highlightMentions(text, you){
   if(!you) return text;
   const re = new RegExp("@"+you.name.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&"), "ig");
   return text.replace(re, '<span class="mention">$&</span>');

--- a/src/pages/ChatRoom.test.js
+++ b/src/pages/ChatRoom.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { autolink, highlightMentions } from './ChatRoom.jsx';
+
+describe('ChatRoom helper functions', () => {
+  it('autolink transforms URLs into anchor tags', () => {
+    const input = 'visit http://a.com';
+    const expected = 'visit <a class="autolink" target="_blank" rel="noreferrer" href="http://a.com">http://a.com</a>';
+    expect(autolink(input)).toBe(expected);
+  });
+
+  it('highlightMentions wraps mentions with span.mention', () => {
+    const input = 'hello @user';
+    const expected = 'hello <span class="mention">@user</span>';
+    expect(highlightMentions(input, { name: 'user' })).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- export autolink and highlightMentions helpers
- add Vitest unit tests for autolink and highlightMentions
- wire up `npm test` script via npx vitest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73ff1a64c8325a24f2a02252d9e03