### PR TITLE
fix: show initial user count

### DIFF
--- a/src/pages/ChatRoom.jsx
+++ b/src/pages/ChatRoom.jsx
@@ -46,7 +46,9 @@ export default function ChatRoom({ roomId: roomArg, onExit, token, onUnreadChang
   const [roomId, setRoomId] = useState(typeof roomArg === "object" ? roomArg.id : roomArg);
   const [you, setYou] = useState(null);
   const [messages, setMessages] = useState([]);
-  const [countUsers, setCountUsers] = useState([]);
+  // Track the number of users in the room. Start from 0 instead of an empty array
+  // so the initial render shows "0" users rather than nothing.
+  const [countUsers, setCountUsers] = useState(0);
   const [users, setUsers] = useState([]);
   const inputRef = useRef(null);
   const [menu, setMenu] = useState({ x: null, y: null, target: null });


### PR DESCRIPTION
## Summary
- ensure user list count in chat room starts at 0 to display correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a73eb7010083259be004d607976396