### PR TITLE
Limit chat message length to 255 characters

### DIFF
--- a/src/pages/ChatRoom.jsx
+++ b/src/pages/ChatRoom.jsx
@@ -18,6 +18,9 @@ export function highlightMentions(text, you){
   const re = new RegExp("@"+you.name.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&"), "ig");
   return text.replace(re, '<span class="mention">$&</span>');
 }
+export function limitMessage(text){
+  return text.slice(0,255);
+}
 function emojiRender(text){ return text.replace(/:coffee:/g,"☕").replace(/:heart:/g,"❤️"); }
 
 function ContextMenu({ x, y, onClose, actions = [] }) {
@@ -172,7 +175,7 @@ export default function ChatRoom({ roomId: roomArg, onExit, token, onUnreadChang
   }, [messages]);
 
   const send = () => {
-    const v = inputRef.current.value.trim();
+    const v = limitMessage(inputRef.current.value.trim());
     if (!v) return;
     onUnreadChange?.(0);
     setPendingBelow(0);
@@ -298,6 +301,7 @@ export default function ChatRoom({ roomId: roomArg, onExit, token, onUnreadChang
               ref={inputRef}
               placeholder={t("type_message")}
               className="chat-input"
+              maxLength={255}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
                   send();

--- a/src/pages/ChatRoom.test.js
+++ b/src/pages/ChatRoom.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { autolink, highlightMentions } from './ChatRoom.jsx';
+import { autolink, highlightMentions, limitMessage } from './ChatRoom.jsx';
 
 describe('ChatRoom helper functions', () => {
   it('autolink transforms URLs into anchor tags', () => {
@@ -12,5 +12,10 @@ describe('ChatRoom helper functions', () => {
     const input = 'hello @user';
     const expected = 'hello <span class="mention">@user</span>';
     expect(highlightMentions(input, { name: 'user' })).toBe(expected);
+  });
+
+  it('limitMessage truncates messages over 255 characters', () => {
+    const longText = 'a'.repeat(300);
+    expect(limitMessage(longText).length).toBe(255);
   });
 });


### PR DESCRIPTION
## Summary
- restrict chat messages to 255 characters with `limitMessage`
- enforce limit in sender and input field
- add tests for message length helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74820cdd0832595e91d303fe669f7